### PR TITLE
Improve chatbot style with dark theme

### DIFF
--- a/assets/css/simple.css
+++ b/assets/css/simple.css
@@ -4,11 +4,14 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background: #000;
+  color: #fff;
 }
 
 header {
   text-align: center;
   padding: 3rem 1rem;
+  background: #111;
 }
 
 header h1 {
@@ -28,25 +31,58 @@ header h1 {
 #chat-container {
   margin-top: auto;
   padding: 1rem;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #333;
+  background: #111;
 }
 
 #chat-log {
-  border: 1px solid #ccc;
+  border: 1px solid #444;
   padding: 0.5rem;
   height: 300px;
   overflow-y: auto;
   margin-bottom: 0.5rem;
+  background: #000;
 }
 
 #chat-input {
   flex: 1;
   padding: 0.5rem;
   font-size: 1rem;
+  background: #222;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
 }
 
 #send-button {
   padding: 0.5rem 1rem;
   margin-left: 0.5rem;
   font-size: 1rem;
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#chat-input::placeholder {
+  color: #bbb;
+}
+
+.chat-message {
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+  max-width: 80%;
+}
+
+.chat-message.user {
+  background: #222;
+  margin-left: auto;
+  text-align: right;
+}
+
+.chat-message.ai {
+  background: #333;
+  margin-right: auto;
 }

--- a/assets/js/chatbot.js
+++ b/assets/js/chatbot.js
@@ -38,7 +38,8 @@ function updateChatLog() {
   log.innerHTML = '';
   for (const m of messages) {
     const div = document.createElement('div');
-    div.textContent = (m.role === 'user' ? 'You: ' : 'AI: ') + m.content;
+    div.className = 'chat-message ' + (m.role === 'user' ? 'user' : 'ai');
+    div.textContent = m.content;
     log.appendChild(div);
   }
   log.scrollTop = log.scrollHeight;


### PR DESCRIPTION
## Summary
- use a black background with white text
- refresh chatbot UI styling
- show messages in modern chat bubbles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685356f51aa48330a0b09260eea1188d